### PR TITLE
Tone down statement

### DIFF
--- a/index.html
+++ b/index.html
@@ -626,7 +626,7 @@ So, the challenge is enabling this technological innovation by being aware of th
     <li data-md>
      <p><strong>Privacy loss</strong> (<em>surveillance</em>): if this technology is not designed and implemented properly, it can lead to surveillance by state and non-state actors such as government and private technology providers. For example, centralized or federated models are more prone to these threats, while decentralized models are less so, but it depends on how they are implemented. Therefore, it is necessary to provide privacy-preserving technologies and implement them properly.</p>
    </ul>
-   <p class="note" role="note"><span class="marker">Note:</span> W3C is handling this issue with a <a href="#a5">Threat Model</a>.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> W3C might consider handling this issue with a <a href="#a5">Threat Model</a>.</p>
    <h3 class="heading settled" data-level="2.3" id="digital-identity-management-models"><span class="secno">2.3. </span><span class="content">Digital identity management models</span><a class="self-link" href="#digital-identity-management-models"></a></h3>
    <p>With these assumptions, before proceeding, it is important to understand how digital identities are managed and how they have evolved over the years.</p>
    <p>Let us start with the example of a person’s identity, and break it down. We had:</p>


### PR DESCRIPTION
"W3C is handling this issue with a Threat Model." implies endorsement by W3C members. But the link brings the reader to a use case within the document, which attempts to summarize an introduction to "Trust over IP" from 2021 by the "trust over IP foundation" which is a 35-page PDF hosted elsewhere. 

This is misleading and risky to make such a claim and to rely on a document whose status is unclear at a cursory glance.