### PR TITLE
add IndieAuth to Standards section with TR link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -424,7 +424,7 @@ Note: Not all of the technologies indicated are standard, so they should not be 
 This is why several Standards Development Organizations (SDOs) such as the World Wide Web Consortium (W3C), the Internet Engineering Task Force (IETF), the OpenID Foundation (OIDF), and the Decentralized Identity Foundation (DIF) are coordinating to standardize the components and how they should communicate:
 
 * **Data Models:** abstract models for Credentials and Presentation such as the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model/) and mDL in ISO/IEC [18013-5:2021](https://www.iso.org/standard/69084.html).  
-* **Identifiers**: [DIDs](https://www.w3.org/TR/did-core/) and the [DID methods](https://w3c.github.io/did-spec-registries/#did-methods), or [WebID](https://w3c.github.io/WebID/spec/identity/).  
+* **Identifiers**: [DIDs](https://www.w3.org/TR/did-core/) and the [DID methods](https://w3c.github.io/did-spec-registries/#did-methods), [IndieAuth](https://www.w3.org/TR/indieauth/), or [WebID](https://w3c.github.io/WebID/spec/identity/).  
 * **Encoding Schemas:** JSON, JSON-LD, CBOR, CBOR-LD.  
 * **Securing Mechanisms:** Each mechanism may or may not support different privacy features or be quantum-resistant:  
     * **Enveloped Formats (Credential Formats)**: The proof wraps around the serialization of the credential.  


### PR DESCRIPTION
add https://www.w3.org/TR/indieauth/ to Standards / Identifiers section in list along with WebID.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tantek/identity-web-impact/pull/39.html" title="Last updated on Sep 13, 2024, 9:34 AM UTC (d971987)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/identity-web-impact/39/9afdccb...tantek:d971987.html" title="Last updated on Sep 13, 2024, 9:34 AM UTC (d971987)">Diff</a>